### PR TITLE
Update to spark 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.zzeekk</groupId>
 	<artifactId>spark-temporalquery</artifactId>
-	<version>0.9.4</version>
+	<version>0.9.5</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
@@ -11,7 +11,7 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql_2.11</artifactId>
-			<version>2.2.1</version>
+			<version>2.3.1</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/scala/ch/zzeekk/spark/temporalquery/TemporalQueryUtil.scala
+++ b/src/main/scala/ch/zzeekk/spark/temporalquery/TemporalQueryUtil.scala
@@ -199,7 +199,7 @@ object TemporalQueryUtil {
     val udf_plusMillisecond = udf(plusMillisecond _)
     val dataCols = df.columns.diff( keys ++ hc.technicalColNames )
     val hashCols = dataCols.diff( ignoreColNames )
-    df.withColumn("_hash", udf_hash(struct(hashCols.map(col(_)):_*)))
+    df.withColumn("_hash", if(hashCols.isEmpty) lit(1) else udf_hash(struct(hashCols.map(col(_)):_*)))
       .withColumn("_hash_prev", lag($"_hash",1).over(Window.partitionBy(keys.map(col):_*).orderBy(col(hc.fromColName))))
       .withColumn("_ersetzt_prev", lag(col(hc.toColName),1).over(Window.partitionBy(keys.map(col):_*).orderBy(col(hc.fromColName))))
       .withColumn("_consecutive", $"_hash_prev".isNotNull and $"_hash"===$"_hash_prev" and udf_plusMillisecond($"_ersetzt_prev")===col(hc.fromColName))


### PR DESCRIPTION
- bump version to 0.9.5
- spark version 2.2.1 to 2.3.1
- correct temporalCombineImpl to accept dataframes with key and technical columns only