### PR TITLE
transforming data frame with continuous time to frame with discrete time

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,16 @@ You can then use the following additional functions on Dataset/DataFrame
   Solve temporal overlaps by a prioritizing Records according to rnkExpressions and extend the temporal range of each key to be defined over the whole timeline. The resulting DataFrame has an additional column `_defined` which is false for extended ranges.
   - aggExpressions: Aggregates to be calculated on overlapping records (e.g. count)
   - rnkFilter: Flag if overlapping records should be tagged or filtered (default=filtered=true)
-- `temporalCombine( keys:Seq[String] = Seq(), ignoreColNames:Seq[String] = Seq() )(implicit ss:SparkSession, hc:TemporalQueryConfig)`
+- `temporalCombine( keys:Seq[String] = Seq(), ignoreColNames:Seq[String] = Seq() )`
   Combines successive records if there are no changes on the non-technical attributes.
   **The parameter `keys` is superfluous. Please refrain from using it!**
   It is still present in order not to break the API.
   - ignoreColName: A list of columns to be ignored in change detection
-- `temporalUnifyRanges( keys:Seq[String] )(implicit ss:SparkSession, hc:TemporalQueryConfig)`
+- `temporalUnifyRanges( keys:Seq[String] )`
   Unify temporal ranges in group of records defined by 'keys' (needed for temporal aggregations).
 - `temporalExtendRange( keys:Seq[String], extendMin:Boolean=true, extendMax:Boolean=true )`
   Extend temporal range to min/maxDate according to TemporalQueryConfig
+- `temporalContinuous2discrete`
+  sets the discreteness of the time scale to milliseconds
+- `temporalRoundDiscreteTime`
+  transforms a data frame with continuous time to a frame with discrete time

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ You can then use the following additional functions on Dataset/DataFrame
 - `temporalExtendRange( keys:Seq[String], extendMin:Boolean=true, extendMax:Boolean=true )`
   Extend temporal range to min/maxDate according to TemporalQueryConfig
 - `temporalContinuous2discrete`
-  sets the discreteness of the time scale to milliseconds
-- `temporalRoundDiscreteTime`
   transforms a data frame with continuous time to a frame with discrete time
+- `temporalRoundDiscreteTime`
+  sets the discreteness of the time scale to milliseconds

--- a/src/main/scala/ch/zzeekk/spark/temporalquery/TemporalQueryUtil.scala
+++ b/src/main/scala/ch/zzeekk/spark/temporalquery/TemporalQueryUtil.scala
@@ -133,6 +133,13 @@ object TemporalQueryUtil extends LazyLogging {
      */
     def temporalRoundDiscreteTime(implicit hc:TemporalQueryConfig): DataFrame = shrinkValidityImpl(df1)(udf_floorTimestamp(hc))
 
+    /**
+     * Transforms [[DataFrame]] with continuous time, half open time intervals [fromColName , toColName [, to discrete time ([fromColName , toColName])
+     * @return [[DataFrame]] with discrete time axis
+     */
+    def temporalContinuous2discrete(implicit hc:TemporalQueryConfig): DataFrame = shrinkValidityImpl(df1)(udf_predecessorTime)
+
+
   }
 
   // helpers

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
@@ -10,6 +10,24 @@ import TestUtils._
 class TemporalQueryUtilTest extends FunSuite {
   import session.implicits._
 
+  test("temporalContinuous2discrete") {
+    val actual = dfContinuousTime.temporalContinuous2discrete(defaultConfig)
+    val expected = Seq(
+      (0,"2019-01-01 00:00:00.124","2019-01-05 12:34:56.123", 3.14),
+      (0,"2019-01-05 12:34:56.124","2019-02-01 02:34:56.123", 2.72),
+      (0,"2019-02-01 02:34:56.124","2019-02-01 02:34:56.124",42.0 ),
+      (0,"2019-02-01 02:34:56.125","2019-03-02 23:59:59.999",13.0 ),
+      (0,"2019-03-03 00:00:0"     ,"2019-04-03 23:59:59.999",12.0 ),
+      (0,"2020-01-01 01:00:0"     ,finisTemporisString,18.17),
+      (1,"2019-01-01 00:00:0.124" ,"2019-02-01 23:59:59.999",-1.0 ),
+      (1,"2019-03-03 01:00:0"     ,"2021-12-01 02:34:56.099",-2.0 )
+    ).map(makeRowsWithTimeRange[Int, Double]).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
+
+    val resultat = dfEqual(actual)(expected)
+    if (!resultat) printFailedTestResult("temporalContinuous2discrete",Seq(dfContinuousTime))(actual)(expected)
+    assert(resultat)
+  }
+
   test("temporalRoundDiscreteTime_dfLeft") {
     val actual = dfLeft.temporalRoundDiscreteTime(defaultConfig)
     val expected = dfLeft

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TestUtils.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TestUtils.scala
@@ -173,4 +173,16 @@ object TestUtils extends LazyLogging {
     (1,"2019-01-01 00:00:0"           ,"2019-12-31 23:59:59.999" ,42.0 ))
   val dfDocumentation: DataFrame = rowsDocumentation.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
 
+  val rowsContinuousTime: Seq[(Int, String, String, Double)] = Seq(
+    (0,"2019-01-01 00:00:00.123456789","2019-01-05 12:34:56.123456789", 3.14),
+    (0,"2019-01-05 12:34:56.123456789","2019-02-01 02:34:56.1235"     , 2.72),
+    (0,"2019-02-01 02:34:56.1235"     ,"2019-02-01 02:34:56.1245"     ,42.0 ),
+    (0,"2019-02-01 02:34:56.1245"     ,"2019-03-03 00:00:0"           ,13.0 ),
+    (0,"2019-03-03 00:00:0"           ,"2019-04-04 00:00:0"           ,12.0 ),
+    (0,"2019-09-05 02:34:56.1231"     ,"2019-09-05 02:34:56.1239"     ,42.0 ),
+    (0,"2020-01-01 01:00:0"           ,"9999-12-31 23:59:59.999999999",18.17),
+    (1,"2019-01-01 00:00:0.123456789" ,"2019-02-02 00:00:00"          ,-1.0 ),
+    (1,"2019-03-03 01:00:0"           ,"2021-12-01 02:34:56.1"        ,-2.0 ))
+  val dfContinuousTime: DataFrame = rowsContinuousTime.map(makeRowsWithTimeRange[Int, Double]).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
+
 }


### PR DESCRIPTION
`def temporalContinuous2discrete(implicit hc:TemporalQueryConfig): DataFrame`