### PR TITLE
Educational test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can then use the following additional functions on Dataset/DataFrame
 - `temporalLeftAntiJoin( df2:DataFrame, joinColumns:Seq[String], additionalJoinFilterCondition:Column = lit(true))`
   Left Anti Join of two temporal datasets using a list of key-columns named the same as condition (using-join). "Anti left join" means that the result contains all periods from DataFrame 1 which do not occur in DataFrame2 for the given joinColumns.
   - additionalJoinFilterCondition: you can provide additional non-equi-join conditions which will be combined with the conditions generated from the list of keys.
-  - `temporalCleanupExtend( keys:Seq[String], rnkExpressions:Seq[Column], aggExpressions:Seq[(String,Column)], rnkFilter:Boolean = true, extend: Boolean = true, fillGapsWithNull: Boolean = true )`
+- `temporalCleanupExtend( keys:Seq[String], rnkExpressions:Seq[Column], aggExpressions:Seq[(String,Column)], rnkFilter:Boolean = true, extend: Boolean = true, fillGapsWithNull: Boolean = true )`
   Solve temporal overlaps by a prioritizing Records according to rnkExpressions and extend the temporal range of each key to be defined over the whole timeline. The resulting DataFrame has an additional column `_defined` which is false for extended ranges.
   - aggExpressions: Aggregates to be calculated on overlapping records (e.g. count)
   - rnkFilter: Flag if overlapping records should be tagged or filtered (default=filtered=true)

--- a/src/main/scala/ch/zzeekk/spark/temporalquery/TemporalHelpers.scala
+++ b/src/main/scala/ch/zzeekk/spark/temporalquery/TemporalHelpers.scala
@@ -27,8 +27,8 @@ object TemporalHelpers extends Serializable with Logging {
     else if (!tempus.after(hc.minDate)) hc.minDate
     else Timestamp.from(tempus.toInstant.plusMillis(numMillis))
   }
-  def udf_plusMillisecond(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(addMillisecond(1) _)
-  def udf_minusMillisecond(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(addMillisecond(-1) _)
+  def getUdfPlusMillisecond(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(addMillisecond(1) _)
+  def getUdfMinusMillisecond(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(addMillisecond(-1) _)
 
   /**
    * returns the length of the time interval [subtrahend ; minuend] in milliseconds
@@ -43,7 +43,7 @@ object TemporalHelpers extends Serializable with Logging {
       s"Null values not supported: minuend=$minuend subtrahend=$subtrahend")
     1 + minuend.getTime - subtrahend.getTime
   }
-  def udf_durationInMillis: UserDefinedFunction = udf(durationInMillis _)
+  val udf_durationInMillis: UserDefinedFunction = udf(durationInMillis _)
 
   /**
    * rounds down timestamp tempus to the nearest millisecond
@@ -62,7 +62,7 @@ object TemporalHelpers extends Serializable with Logging {
       resultat
     } else hc.maxDate
   }
-  def udf_floorTimestamp(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(floorTimestamp _)
+  def getUdfFloorTimestamp(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(floorTimestamp _)
 
   /**
    * rounds up timestamp to next ChronoUnit
@@ -71,7 +71,7 @@ object TemporalHelpers extends Serializable with Logging {
    * @return truncated timestamp
    */
   def ceilTimestamp(tempus: Timestamp)(implicit hc:TemporalQueryConfig): Timestamp = addMillisecond(1)(predecessorTime(tempus)(hc))
-  def udf_ceilTimestamp(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(ceilTimestamp _)
+  def getUdfCeilTimestamp(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(ceilTimestamp _)
 
   /**
    * returns the predecessor timestamp with respect to ChronoUnit
@@ -85,7 +85,7 @@ object TemporalHelpers extends Serializable with Logging {
       if (resultat.equals(tempus)) addMillisecond(-1)(resultat) else resultat
     }
   }
-  def udf_predecessorTime(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(predecessorTime _)
+  def getUdfPredecessorTime(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(predecessorTime _)
 
   /**
    * returns the predecessor timestamp with respect to ChronoUnit
@@ -99,7 +99,7 @@ object TemporalHelpers extends Serializable with Logging {
       if (resultat.equals(tempus)) addMillisecond(1)(resultat) else resultat
     }
   }
-  def udf_successorTime(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(successorTime _)
+  def getUdfSuccessorTime(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(successorTime _)
 
   /**
    * returns the complement of union of subtrahends relative to the interval [validFrom, validTo]
@@ -131,6 +131,6 @@ object TemporalHelpers extends Serializable with Logging {
 
     subtrahendsSorted.foldLeft(Seq((validFrom, validTo)))(subtractOneSubtrahend)
   }
-  def udf_temporalComplement(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(temporalComplement _)
+  def getUdfTemporalComplement(implicit hc:TemporalQueryConfig): UserDefinedFunction = udf(temporalComplement _)
 
 }

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
@@ -1,7 +1,7 @@
 package ch.zzeekk.spark.temporalquery
 
 import java.sql.Timestamp
-import java.util.Calendar
+import java.util.{Calendar,TimeZone}
 
 import ch.zzeekk.spark.temporalquery.TemporalHelpers._
 import ch.zzeekk.spark.temporalquery.TestUtils._
@@ -31,8 +31,8 @@ class TemporalHelpersTest extends FunSuite {
   }
 
   test("udf_durationInMillis") {
-    val dstOffset: Long = millisPerHour // Calendar.getInstance().get(Calendar.DST_OFFSET)
-    println(s"test udf_durationInMillis: dstOffset = $dstOffset")
+    println(s"test udf_durationInMillis: Calendar.getInstance().get(Calendar.DST_OFFSET) = ${Calendar.getInstance().get(Calendar.DST_OFFSET)}")
+    val dstOffset: Int = TimeZone.getDefault.getDSTSavings
     val argExpMap = Map[(String, (String, String)), Long](
       ("january 2019: 31 Tage", ("2019-01-31 23:59:59.999", "2019-01-01 00:00:0")) -> 31 * millisPerDay,
       ("Winterzeit überzogen 2019", ("2019-03-31 02:59:59.999", "2019-03-31 02:00:0")) -> millisPerHour,
@@ -47,7 +47,6 @@ class TemporalHelpersTest extends FunSuite {
       ("leap second 1995: 365 Tage (+ 1 second)", ("1995-12-31 23:59:59.999", "1995-01-01 00:00:0")) -> 365 * millisPerDay,
       ("2 leap seconds and leap year 1972: 366 Tage  (+ 2 second)", ("1972-12-31 23:59:59.999", "1972-01-01 00:00:0")) -> 366 * millisPerDay,
       ("just a moment", ("2020-03-17 10:00:0", "2020-03-17 10:00:0")) -> 1L)
-
     testArgumentExpectedMapWithComment[(String, String), Long](x => durationInMillis(Timestamp.valueOf(x._1), Timestamp.valueOf(x._2)),argExpMap)
   }
 

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
@@ -31,7 +31,8 @@ class TemporalHelpersTest extends FunSuite {
   }
 
   test("udf_durationInMillis") {
-    val dstOffset: Long = Calendar.getInstance().get(Calendar.DST_OFFSET)
+    val dstOffset: Long = millisPerHour // Calendar.getInstance().get(Calendar.DST_OFFSET)
+    println(s"test udf_durationInMillis: dstOffset = $dstOffset")
     val argExpMap = Map[(String, (String, String)), Long](
       ("january 2019: 31 Tage", ("2019-01-31 23:59:59.999", "2019-01-01 00:00:0")) -> 31 * millisPerDay,
       ("Winterzeit überzogen 2019", ("2019-03-31 02:59:59.999", "2019-03-31 02:00:0")) -> millisPerHour,

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
@@ -58,7 +58,7 @@ class TemporalHelpersTest extends FunSuite {
     testArgumentExpectedMapWithComment[Timestamp, Timestamp](floorTimestamp, argExpMap)
   }
 
-  test("udf_predecessorTime") {
+  test("predecessorTime") {
     val argExpMap: Map[(String,Timestamp),Timestamp] = Map(
       ("cut of fraction of millisecond"         ,Timestamp.valueOf("1998-09-05 14:34:56.123456789")) -> Timestamp.valueOf("1998-09-05 14:34:56.123"),
       ("subtract a millisecond as no fraction of millisecond",Timestamp.valueOf("2019-03-03 00:00:0")) -> Timestamp.valueOf("2019-03-02 23:59:59.999")
@@ -67,6 +67,16 @@ class TemporalHelpersTest extends FunSuite {
   }
 
   test("udf_successorTime") {
+    import session.implicits._
+    //TODO: Clarify why we need to specify explicitly the implicit parameter hc of UDF
+    val actual = dfLeft.select(udf_successorTime(defaultConfig)(defaultConfig.fromCol).as(defaultConfig.fromColName))
+    val expected = Seq(Timestamp.valueOf("2017-12-10 00:00:00.001")).toDF(defaultConfig.fromColName)
+    val resultat = dfEqual(actual)(expected)
+    if (!resultat) printFailedTestResult("udf_successorTime",Seq(dfLeft))(actual)(expected)
+    assert(resultat)
+  }
+
+  test("successorTime") {
     val argExpMap: Map[(String,Timestamp),Timestamp] = Map(
       ("round up millisecond"         ,Timestamp.valueOf("1998-09-05 14:34:56.123456789")) -> Timestamp.valueOf("1998-09-05 14:34:56.124"),
       ("add a millisecond as no fraction of millisecond",Timestamp.valueOf("2019-03-03 00:00:0")) -> Timestamp.valueOf("2019-03-03 00:00:0.001")

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalHelpersTest.scala
@@ -22,7 +22,7 @@ class TemporalHelpersTest extends FunSuite {
     testArgumentExpectedMap[(Int,Timestamp), Timestamp](x=>addMillisecond(x._1)(x._2), argExpMap)
   }
 
-  test("udf_ceilTimestamp") {
+  test("getUdfCeilTimestamp") {
     val argExpMap: Map[(String,Timestamp),Timestamp] = Map(
       ("round up to next millisecond"           ,Timestamp.valueOf("1998-09-05 14:34:56.123456789")) -> Timestamp.valueOf("1998-09-05 14:34:56.124"),
       ("no change as no fraction of millisecond",Timestamp.valueOf("2019-03-03 00:00:0")) -> Timestamp.valueOf("2019-03-03 00:00:0")
@@ -50,7 +50,7 @@ class TemporalHelpersTest extends FunSuite {
     testArgumentExpectedMapWithComment[(String, String), Long](x => durationInMillis(Timestamp.valueOf(x._1), Timestamp.valueOf(x._2)),argExpMap)
   }
 
-  test("udf_floorTimestamp") {
+  test("getUdfFloorTimestamp") {
     val argExpMap: Map[(String,Timestamp),Timestamp] = Map(
       ("cut of fraction of millisecond"         ,Timestamp.valueOf("1998-09-05 14:34:56.123456789")) -> Timestamp.valueOf("1998-09-05 14:34:56.123"),
       ("no change as no fraction of millisecond",Timestamp.valueOf("2019-03-03 00:00:0")) -> Timestamp.valueOf("2019-03-03 00:00:0")
@@ -66,13 +66,12 @@ class TemporalHelpersTest extends FunSuite {
     testArgumentExpectedMapWithComment[Timestamp, Timestamp](predecessorTime, argExpMap)
   }
 
-  test("udf_successorTime") {
+  test("getUdfSuccessorTime") {
     import session.implicits._
-    //TODO: Clarify why we need to specify explicitly the implicit parameter hc of UDF
-    val actual = dfLeft.select(udf_successorTime(defaultConfig)(defaultConfig.fromCol).as(defaultConfig.fromColName))
+    val actual = dfLeft.select(getUdfSuccessorTime(defaultConfig)(defaultConfig.fromCol).as(defaultConfig.fromColName))
     val expected = Seq(Timestamp.valueOf("2017-12-10 00:00:00.001")).toDF(defaultConfig.fromColName)
     val resultat = dfEqual(actual)(expected)
-    if (!resultat) printFailedTestResult("udf_successorTime",Seq(dfLeft))(actual)(expected)
+    if (!resultat) printFailedTestResult("getUdfSuccessorTime",Seq(dfLeft))(actual)(expected)
     assert(resultat)
   }
 
@@ -84,7 +83,7 @@ class TemporalHelpersTest extends FunSuite {
     testArgumentExpectedMapWithComment[Timestamp, Timestamp](successorTime, argExpMap)
   }
 
-  test("udf_temporalComplement") {
+  test("getUdfTemporalComplement") {
     val subtrahends = Seq(
       ("2020-01-01 00:04:4","2020-01-01 00:05:0"),
       ("2020-01-01 00:00:1","2020-01-01 00:01:0"),

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
@@ -59,7 +59,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   }
 
   test("temporalCleanupExtend_dfLeft") {
-    val actual = dfLeft.temporalCleanupExtend(Seq("id"),Seq(col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalCleanupExtend(Seq("id"),Seq(defaultConfig.fromCol))
     val expected = Seq(
       (0, None     , initiumTemporisString, "2017-12-09 23:59:59.999"),
       (0, Some(4.2), "2017-12-10 00:00:00", "2018-12-08 23:59:59.999"),
@@ -76,7 +76,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   test("temporalCleanupExtend_dfRight_noExtend_nofillGaps") {
     val actual = dfRight.temporalCleanupExtend(
       keys=Seq("id"),
-      rnkExpressions=Seq(col(defaultConfig.fromColName)),
+      rnkExpressions=Seq(defaultConfig.fromCol),
       extend = false,
       fillGapsWithNull = false
     )
@@ -99,7 +99,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   test("temporalCleanupExtend_dfRight_fillGaps_noExtend") {
     val actual = dfRight.temporalCleanupExtend(
       keys=Seq("id"),
-      rnkExpressions=Seq(col(defaultConfig.fromColName)),
+      rnkExpressions=Seq(defaultConfig.fromCol),
       extend = false
     )
     val expected = Seq(
@@ -121,7 +121,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   test("temporalCleanupExtend_dfRight_extend_nofillGaps") {
     val actual = dfRight.temporalCleanupExtend(
       keys=Seq("id"),
-      rnkExpressions=Seq(col(defaultConfig.fromColName)),
+      rnkExpressions=Seq(defaultConfig.fromCol),
       fillGapsWithNull = false
     )
     val expected = Seq(
@@ -143,7 +143,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   test("temporalCleanupExtend_dfRight_extend_fillGaps") {
     val actual = dfRight.temporalCleanupExtend(
       keys=Seq("id"),
-      rnkExpressions=Seq(col(defaultConfig.fromColName)))
+      rnkExpressions=Seq(defaultConfig.fromCol))
     val expected = Seq(
       (0, None        , initiumTemporisString , "2017-12-31 23:59:59.999"),
       (0, Some(97.15) , "2018-01-01 00:00:00", "2018-01-31 23:59:59.999"),
@@ -193,7 +193,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   }
 
   test("temporalCleanupExtend_dfMsOverlap") {
-    val actual = dfMsOverlap.temporalCleanupExtend(Seq("id"),Seq(col(defaultConfig.fromColName)))
+    val actual = dfMsOverlap.temporalCleanupExtend(Seq("id"),Seq(defaultConfig.fromCol))
     val expected = Seq(
       (0, None     , initiumTemporisString    , "2018-12-31 23:59:59.999"),
       (0, Some("A"), "2019-01-01 00:00:00"    , "2019-01-01 10:00:00"),
@@ -209,7 +209,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   }
 
   test("temporalCleanupExtend_dfDirtyTimeRanges") {
-    val actual = dfDirtyTimeRanges.temporalCleanupExtend(Seq("id"),Seq(col(defaultConfig.fromColName),$"wert"))
+    val actual = dfDirtyTimeRanges.temporalCleanupExtend(Seq("id"),Seq(defaultConfig.fromCol,$"wert"))
     val expected = Seq(
       (0, None       , initiumTemporisString    , "2019-01-01 00:00:00.123"),
       (0, Some(3.14) , "2019-01-01 00:00:00.124", "2019-01-05 12:34:56.123"),
@@ -236,7 +236,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   }
 
   test("temporalCleanupExtend_dfDirtyTimeRanges_NoExtendFillgaps") {
-    val actual = dfDirtyTimeRanges.temporalCleanupExtend(Seq("id"),Seq(col(defaultConfig.fromColName),$"wert"),extend=false,fillGapsWithNull=false)
+    val actual = dfDirtyTimeRanges.temporalCleanupExtend(Seq("id"),Seq(defaultConfig.fromCol,$"wert"),extend=false,fillGapsWithNull=false)
     val expected = Seq(
       (0, 3.14, "2019-01-01 00:00:00.124", "2019-01-05 12:34:56.123"),
       (0, 2.72, "2019-01-05 12:34:56.124", "2019-02-01 02:34:56.124"),
@@ -265,7 +265,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
     ).map(makeRowsWithTimeRangeEnd[Int, String])
       .toDF("id", "val", defaultConfig.fromColName, defaultConfig.toColName)
     // we want the record with the longest validity period, i.e. maximal toColName-fromColName
-    val actual = argument.temporalCleanupExtend(Seq("id"), Seq(udf_durationInMillis(col(defaultConfig.toColName),col(defaultConfig.fromColName)).desc))
+    val actual = argument.temporalCleanupExtend(Seq("id"), Seq(udf_durationInMillis(defaultConfig.toCol,defaultConfig.fromCol).desc))
     val expected = Seq(
       (1, None     , initiumTemporisString, "2020-06-30 23:59:59.999"),
       (1, Some("A"), "2020-07-01 00:00:00", "2020-07-03 23:59:59.999"),
@@ -285,7 +285,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
       (1, "X", "2020-07-01 00:00:00", finisTemporisString)
     ).map(makeRowsWithTimeRangeEnd[Int, String])
       .toDF("id", "val", defaultConfig.fromColName, defaultConfig.toColName)
-    val actual = argument.temporalCleanupExtend(Seq("id"), Seq(col(defaultConfig.fromColName)))
+    val actual = argument.temporalCleanupExtend(Seq("id"), Seq(defaultConfig.fromCol))
     val expected = Seq(
       (1, "S", initiumTemporisString, finisTemporisString)
     ).map(makeRowsWithTimeRangeEnd[Int, String])
@@ -304,7 +304,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
       (1,"G","2020-09-24 00:00:00",finisTemporisString)
     ).map(makeRowsWithTimeRangeEnd[Int,String])
       .toDF("id","val",defaultConfig.fromColName, defaultConfig.toColName)
-    val actual = argument.temporalCleanupExtend(Seq("id"),Seq(col(defaultConfig.toColName).desc,col(defaultConfig.fromColName).asc))(session,defaultConfig)
+    val actual = argument.temporalCleanupExtend(Seq("id"),Seq(defaultConfig.toCol.desc,defaultConfig.fromCol.asc))(session,defaultConfig)
     val expected = Seq(
       (1,"S",initiumTemporisString,"2020-06-30 23:59:59.999"),
       (1,"X","2020-07-01 00:00:00","2020-08-02 23:59:59.999"),
@@ -586,7 +586,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
 
   test("temporalFullJoin_rightMapWithrnkExpressions") {
     // Testing temporalFullJoin where the right dataFrame is not unique for join attributes
-    val actual = dfLeft.temporalFullJoin(df2=dfMap, keys=Seq("id"), rnkExpressions=Seq($"img",col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalFullJoin(df2=dfMap, keys=Seq("id"), rnkExpressions=Seq($"img",defaultConfig.fromCol))
     val expected = Seq(
       // img = {}
       (Some(0),None     ,None     ,initiumTemporisString  ,"2017-12-09 23:59:59.999"),
@@ -617,7 +617,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
       (0, "2018-02-25 14:15:16.123", "2018-02-25 14:15:16.123", "X"))
       .map(makeRowsWithTimeRange)
       .toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
-    val actual = dfLeft.temporalFullJoin(df2=argumentRight, keys=Seq("id"), rnkExpressions=Seq($"img",col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalFullJoin(df2=argumentRight, keys=Seq("id"), rnkExpressions=Seq($"img",defaultConfig.fromCol))
     val expected = Seq(
       // img = {}
       (Some(0),None     ,None     ,initiumTemporisString  ,"2017-12-09 23:59:59.999"),
@@ -675,7 +675,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
 
   test("temporalLeftJoin_rightMapWithrnkExpressions") {
     // Testing temporalLeftJoin where the right dataFrame is not unique for join attributes
-    val actual = dfLeft.temporalLeftJoin(df2=dfMap, keys=Seq("id"), rnkExpressions=Seq($"img",col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalLeftJoin(df2=dfMap, keys=Seq("id"), rnkExpressions=Seq($"img",defaultConfig.fromCol))
     val expected =   Seq(
       // img = {}
       (0,4.2,None     ,"2017-12-10 00:00:00","2017-12-31 23:59:59.999"),
@@ -705,7 +705,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
       (0, "2018-02-25 14:15:16.123", "2018-02-25 14:15:16.123", "X"))
       .map(makeRowsWithTimeRange)
       .toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
-    val actual = dfLeft.temporalLeftJoin(df2=argumentRight, keys=Seq("id"), rnkExpressions=Seq($"img",col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalLeftJoin(df2=argumentRight, keys=Seq("id"), rnkExpressions=Seq($"img",defaultConfig.fromCol))
     val expected = Seq(
       // img = {}
       (0,4.2,None     ,"2017-12-10 00:00:00","2017-12-31 23:59:59.999"),
@@ -784,7 +784,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
   test("temporalRightJoin_rightMapWithrnkExpressions") {
     // Testing temporalRightJoin where the right dataFrame is not unique for join attributes
     // but in a right join rnkExpressions are applied to left data frame
-    val actual = dfLeft.temporalRightJoin(df2=dfMap, keys=Seq("id"), rnkExpressions=Seq($"img",col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalRightJoin(df2=dfMap, keys=Seq("id"), rnkExpressions=Seq($"img",defaultConfig.fromCol))
     val expected = Seq(
       // img = {}
       (0,Some(4.2),Some("A"),"2018-01-01 00:00:00","2018-01-31 23:59:59.999"),
@@ -813,7 +813,7 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
       .map(makeRowsWithTimeRange)
       .toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
 
-    val actual = dfLeft.temporalRightJoin(df2=argumentRight, keys=Seq("id"), rnkExpressions=Seq($"img",col(defaultConfig.fromColName)))
+    val actual = dfLeft.temporalRightJoin(df2=argumentRight, keys=Seq("id"), rnkExpressions=Seq($"img",defaultConfig.fromCol))
     val expected = Seq(
       // img = {}
       (0,Some(4.2),Some("A"),"2018-01-01 00:00:00","2018-01-31 23:59:59.999"),

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
@@ -900,6 +900,8 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
     val actual = dfMoment.temporalUnifyRanges(Seq("id"))
       .select(dfMoment.columns.map(col):_*) // re-order columns
     val expected = dfMoment
+    logger.info("expected:")
+    expected.show(false)
     val resultat = dfEqual(actual)(expected)
     if (!resultat) printFailedTestResult("temporalUnifyRanges dfMoment",dfMoment)(actual)(expected)
     assert(resultat)

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
@@ -959,11 +959,10 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
     val actual = dfMicrosecTimeRanges.temporalUnifyRanges(Seq("id"))
     logger.info("\n*** Argument.temporalUnifyRanges(Seq(\"id\")) = ")
     actual.orderBy("id","gueltig_ab").show(false)
-
     val expected = Seq(
       (0, 3.14,"2018-06-01 00:00:00       ","2018-06-01 09:00:00"),
-      (0, 2.72,"2018-06-01 09:00:00.000124","2018-06-01 09:00:00"),
       (0,42.0 ,"2018-06-01 09:00:00.000124","2018-06-01 09:00:00"),
+      (0, 2.72,"2018-06-01 09:00:00.000130","2018-06-01 09:00:00"),
       (0, 2.72,"2018-06-01 09:00:00.001"   ,"2018-06-01 17:00:00.123")
     ).map(makeRowsWithTimeRangeEnd[Int,Double])
       .toDF("id", "wert", defaultConfig.fromColName, defaultConfig.toColName)

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TemporalQueryUtilTest.scala
@@ -846,6 +846,26 @@ class TemporalQueryUtilTest extends FunSuite with Logging {
     assert(resultat)
   }
 
+  test("temporalCombine dropped column") {
+    val actual = dfRight
+      .withColumn("test_column",lit("please drop me"))
+      .drop("test_column")
+      .temporalCombine()
+    val rowsExpected = Seq(
+      (0,"2018-01-01 00:00:00.0","2018-01-31 23:59:59.999",Some(97.15) ),
+      (0,"2018-06-01 05:24:11.0",finisTemporisString      ,Some(97.15) ),
+      (1,"2018-01-01 00:00:00.0","2018-12-31 23:59:59.999",None        ),
+      (1,"2019-01-01 00:00:00.0","2019-12-31 23:59:59.999",Some(2019.0)),
+      (1,"2020-01-01 00:00:00.0","2020-12-31 23:59:59.999",Some(2020.0)),
+      (1,"2021-01-01 00:00:00.0","2099-12-31 23:59:59.999",None        )
+    )
+    val expected = rowsExpected.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName, "wert_r")
+    val resultat = dfEqual(actual)(expected)
+
+    if (!resultat) printFailedTestResult("temporalCombine dropped column",dfRight)(actual)(expected)
+    assert(resultat)
+  }
+
   test("temporalCombine_dfMapToCombine") {
     val actual = dfMapToCombine.temporalCombine()
     val rowsExpected = Seq(

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TestUtils.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TestUtils.scala
@@ -163,7 +163,7 @@ object TestUtils extends Logging {
   val dfMicrosecTimeRanges: DataFrame = Seq(
     (0,"2018-06-01 00:00:00"       ,"2018-06-01 09:00:00.000123", 3.14),
     (0,"2018-06-01 09:00:00.000124","2018-06-01 09:00:00.000129",42.0),
-    (0,"2018-06-01 09:00:00.000124","2018-06-01 17:00:00.123456", 2.72)
+    (0,"2018-06-01 09:00:00.000130","2018-06-01 17:00:00.123456", 2.72)
   ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
 
   // Data Frame dfDirtyTimeRanges

--- a/src/test/scala/ch.zzeekk.spark.temporalquery/TestUtils.scala
+++ b/src/test/scala/ch.zzeekk.spark.temporalquery/TestUtils.scala
@@ -16,7 +16,7 @@ object TestUtils extends Logging {
 
   def symmetricDifference(df1: DataFrame)(df2: DataFrame): DataFrame = {
     // attention, "except" works on Dataset and not on DataFrame. We need to check that schema is equal.
-   require(df1.columns.toSeq==df2.columns.toSeq,
+    require(df1.columns.toSeq==df2.columns.toSeq,
       s"""Cannot calculate symmetric difference for DataFrames with different schema.
          |schema of df1: ${df1.columns.toSeq.mkString(" ;")}
          |${df1.schema.treeString}
@@ -94,10 +94,10 @@ object TestUtils extends Logging {
   def makeRowsWithTimeRangeEnd[A,B,C](zeile: (A, B, C, String, String)): (A, B, C, Timestamp, Timestamp) = (zeile._1,zeile._2,zeile._3,Timestamp.valueOf(zeile._4),Timestamp.valueOf(zeile._5))
   def makeRowsWithTimeRangeEnd[A,B,C,D](zeile: (A, B, C, D, String, String)): (A, B, C, D, Timestamp, Timestamp) = (zeile._1,zeile._2,zeile._3,zeile._4,Timestamp.valueOf(zeile._5),Timestamp.valueOf(zeile._6))
 
-  val rowsLeft: Seq[(Int, String, String, Double)] = Seq((0, "2017-12-10 00:00:00", "2018-12-08 23:59:59.999", 4.2))
-  val dfLeft: DataFrame = rowsLeft.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert_l")
+  val dfLeft: DataFrame = Seq((0, "2017-12-10 00:00:00", "2018-12-08 23:59:59.999", 4.2))
+    .map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert_l")
 
-  val rowsRight: Seq[(Int, String, String, Option[Double])] = Seq(
+  val dfRight: DataFrame = Seq(
     (0, "2018-01-01 00:00:00", "2018-01-31 23:59:59.999", Some(97.15)),
     // gap in history
     (0, "2018-06-01 05:24:11", "2018-10-23 03:50:09.999", Some(97.15)),
@@ -106,10 +106,10 @@ object TestUtils extends Logging {
     (1, "2018-01-01 00:00:00", "2018-12-31 23:59:59.999", None),
     (1, "2019-01-01 00:00:00", "2019-12-31 23:59:59.999", Some(2019.0)),
     (1, "2020-01-01 00:00:00", "2020-12-31 23:59:59.999", Some(2020.0)),
-    (1, "2021-01-01 00:00:00", "2099-12-31 23:59:59.999", None))
-  val dfRight: DataFrame = rowsRight.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert_r")
+    (1, "2021-01-01 00:00:00", "2099-12-31 23:59:59.999", None)
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert_r")
 
-  val rowsRightDouble: Seq[(Double, String, String, Option[Double])] = Seq(
+  val dfRightDouble: DataFrame = Seq(
     (0.0, "2018-01-01 00:00:00", "2018-01-31 23:59:59.999", Some(97.15)),
     // gap in history
     (0.0, "2018-06-01 05:24:11", "2018-10-23 03:50:09.999", Some(97.15)),
@@ -118,22 +118,22 @@ object TestUtils extends Logging {
     (1.0, "2018-01-01 00:00:00", "2018-12-31 23:59:59.999", None),
     (1.0, "2019-01-01 00:00:00", "2019-12-31 23:59:59.999", Some(2019.0)),
     (1.0, "2020-01-01 00:00:00", "2020-12-31 23:59:59.999", Some(2020.0)),
-    (1.0, "2021-01-01 00:00:00", "2099-12-31 23:59:59.999", None))
-  val dfRightDouble: DataFrame = rowsRightDouble.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert_r")
+    (1.0, "2021-01-01 00:00:00", "2099-12-31 23:59:59.999", None)
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert_r")
+
   /*
     * dfMap: dfMap which maps a set of images img to id over time:
     * e.g. 0 ↦ {A,B} in Jan 2018 ; 0 ↦ {B,C} 1.-19. Feb 2018 ; 0 ↦ {B,C,D} 20.-28. Feb 2018 ausser für eine 1ms mit 0 ↦ {B,C,D,X} ; 0 ↦ {D} in Mar 2018
   */
-  val rowsMap: Seq[(Int, String, String, String)] = Seq(
+  val dfMap: DataFrame = Seq(
     (0, "2018-01-01 00:00:00", "2018-01-31 23:59:59.999", "A"),
     (0, "2018-01-01 00:00:00", "2018-02-28 23:59:59.999", "B"),
     (0, "2018-02-01 00:00:00", "2018-02-28 23:59:59.999", "C"),
     (0, "2018-02-20 00:00:00", "2018-03-31 23:59:59.999", "D"),
     (0, "2018-02-25 14:15:16.123", "2018-02-25 14:15:16.123", "X")
-  )
-  val dfMap: DataFrame = rowsMap.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
 
-  val rowsMapToCombine: Seq[(Int, String, String, Option[String])] = Seq(
+  val dfMapToCombine: DataFrame = Seq(
     (0, "2018-01-01 00:00:00", "2018-03-31 23:59:59.999", Some("A")),
     (0, "2018-04-01 00:00:00", "2018-07-31 23:59:59.999", Some("A")),
     (0, "2018-08-01 00:00:00", "2018-08-31 23:59:59.999", Some("A")),
@@ -148,19 +148,26 @@ object TestUtils extends Logging {
     (1, "2020-06-01 00:00:00", "2020-12-31 23:59:59.999", Some("one")),
     (0, "2018-02-20 00:00:00", "2018-03-31 23:59:59.999", Some("D")),
     (0, "2018-02-25 14:15:16.123", "2018-02-25 14:15:16.123", Some("X"))
-  )
-  val dfMapToCombine: DataFrame = rowsMapToCombine.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
 
-  val rowsMoment: Seq[(Int, String, String, String)] = Seq((0, "2019-11-25 11:12:13.005", "2019-11-25 11:12:13.005", "A"))
-  val dfMoment: DataFrame = rowsMoment.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
+  val dfMoment: DataFrame = Seq((0, "2019-11-25 11:12:13.005", "2019-11-25 11:12:13.005", "A"))
+    .map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
 
   // for 1ms, namely [10:00:00.000,10:00:00.001[, the image set is {A,B}
-  val rowsMsOverlap: Seq[(Int, String, String, String)] = Seq((0, "2019-01-01 00:00:00", "2019-01-01 10:00:00", "A"),
-    (0, "2019-01-01 10:00:00", "2019-01-01 23:59:59.999", "B"))
-  val dfMsOverlap: DataFrame = rowsMsOverlap.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
+  val dfMsOverlap: DataFrame = Seq(
+    (0, "2019-01-01 00:00:00", "2019-01-01 10:00:00", "A"),
+    (0, "2019-01-01 10:00:00", "2019-01-01 23:59:59.999", "B")
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"img")
 
   // Data Frame dfDirtyTimeRanges
-  val rowsDirtyTimeRanges: Seq[(Int, String, String, Double)] = Seq(
+  val dfMicrosecTimeRanges: DataFrame = Seq(
+    (0,"2018-06-01 00:00:00"       ,"2018-06-01 09:00:00.000123", 3.14),
+    (0,"2018-06-01 09:00:00.000124","2018-06-01 09:00:00.000129",42.0),
+    (0,"2018-06-01 09:00:00.000124","2018-06-01 17:00:00.123456", 2.72)
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
+
+  // Data Frame dfDirtyTimeRanges
+  val dfDirtyTimeRanges: DataFrame = Seq(
     (0,"2019-01-01 00:00:00.123456789","2019-01-05 12:34:56.123456789", 3.14),
     (0,"2019-01-05 12:34:56.123456789","2019-02-01 02:34:56.1235"     , 2.72),
     (0,"2019-02-01 01:00:00.0"        ,"2019-02-01 02:34:56.1245"     , 2.72), // overlaps with previous record
@@ -176,17 +183,17 @@ object TestUtils extends Logging {
     (1,"2019-03-01 00:00:0.0009"      ,"2019-03-01 00:00:00.001"      , 0.1 ), // duration less than a millisecond, overlaps with previous record
     (1,"2019-03-01 00:00:1.0009"      ,"2019-03-01 00:00:01.0021"     , 1.2 ), // duration less than a millisecond
     (1,"2019-03-01 00:00:0.0001"      ,"2019-03-01 00:00:00.0009"     , 0.8 ), // duration less than a millisecond
-    (1,"2019-03-03 01:00:0"           ,"2021-12-01 02:34:56.1"        ,-2.0 ))
-  val dfDirtyTimeRanges: DataFrame = rowsDirtyTimeRanges.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
+    (1,"2019-03-03 01:00:0"           ,"2021-12-01 02:34:56.1"        ,-2.0 )
+  ).map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
 
-  val rowsDocumentation: Seq[(Int, String, String, Double)] = Seq(
+  val dfDocumentation: DataFrame = Seq(
     (1,"2019-01-05 12:34:56.123456789","2019-02-01 02:34:56.1235", 2.72),
     (1,"2019-02-01 01:00:00.0"        ,"2019-02-01 02:34:56.1245", 2.72), // overlaps with previous record
     (1,"2019-02-01 02:34:56.125"      ,"2019-02-01 02:34:56.1245", 2.72), // ends before it starts
-    (1,"2019-01-01 00:00:0"           ,"2019-12-31 23:59:59.999" ,42.0 ))
-  val dfDocumentation: DataFrame = rowsDocumentation.map(makeRowsWithTimeRange).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
+    (1,"2019-01-01 00:00:0"           ,"2019-12-31 23:59:59.999" ,42.0 )
+  ).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
 
-  val rowsContinuousTime: Seq[(Int, String, String, Double)] = Seq(
+  val dfContinuousTime: DataFrame = Seq(
     (0,"2019-01-01 00:00:00.123456789","2019-01-05 12:34:56.123456789", 3.14),
     (0,"2019-01-05 12:34:56.123456789","2019-02-01 02:34:56.1235"     , 2.72),
     (0,"2019-02-01 02:34:56.1235"     ,"2019-02-01 02:34:56.1245"     ,42.0 ),
@@ -195,7 +202,7 @@ object TestUtils extends Logging {
     (0,"2019-09-05 02:34:56.1231"     ,"2019-09-05 02:34:56.1239"     ,42.0 ),
     (0,"2020-01-01 01:00:0"           ,"9999-12-31 23:59:59.999999999",18.17),
     (1,"2019-01-01 00:00:0.123456789" ,"2019-02-02 00:00:00"          ,-1.0 ),
-    (1,"2019-03-03 01:00:0"           ,"2021-12-01 02:34:56.1"        ,-2.0 ))
-  val dfContinuousTime: DataFrame = rowsContinuousTime.map(makeRowsWithTimeRange[Int, Double]).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
+    (1,"2019-03-03 01:00:0"           ,"2021-12-01 02:34:56.1"        ,-2.0 )
+  ).toDF("id", defaultConfig.fromColName, defaultConfig.toColName,"wert")
 
 }


### PR DESCRIPTION
to highlight the behaviour of temporalUnifyRanges when the time has a granularity of smaller than 1ms.

and a few simplifications.